### PR TITLE
MCP3-685: Fix "Create TV" option not working

### DIFF
--- a/modules/servers/mediacpcloud/mediacpcloud.php
+++ b/modules/servers/mediacpcloud/mediacpcloud.php
@@ -342,7 +342,7 @@ function mediacpcloud_CreateAccount(array $params)
 	}
 	
 	# Create tv channel
-	if ( $params['configoption2'] == 'on' ){
+	if ( $params['configoption3'] == 'on' ){
 		
 		$channelName = $params['clientsdetails']['fullname'] . "'s TV Channel";
 		if ( !empty($params['clientdetails']['companyname']) && strlen($params['clientdetails']['companyname']) > 2 ){


### PR DESCRIPTION
Resolves MCP3-685

Was a simple one - "Create Live Channel" option would have been creating a TV Channel too, as the Live Channel checkbox was being checked as the trigger for the TV Channel creation.